### PR TITLE
Revert "fix: escape the content"

### DIFF
--- a/index.go
+++ b/index.go
@@ -23,7 +23,7 @@ const indexTmpl string = `
         {{- if .ContentURL }}
         url: '{{ .ContentURL }}',
         {{- else }}
-        content: {{ .BT }}{{ jsEscape .Content }}{{ .BT }},
+        content: {{ .BT }}{{ .Content }}{{ .BT }},
         {{- end }}
         proxyUrl: '{{ .ProxyURL }}',
         title: '{{ .Title }}',

--- a/scalar.go
+++ b/scalar.go
@@ -22,14 +22,7 @@ var HandlerDefault = New()
 func New(config ...Config) fiber.Handler {
 	cfg := configDefault(config...)
 
-	index := template.New("scalar_index.html")
-	index.Funcs(template.FuncMap{
-		"jsEscape": func(s string) template.HTML {
-			return template.HTML(strings.ReplaceAll(s, "'", "\\'"))
-		},
-	})
-
-	index, err := index.Parse(indexTmpl)
+	index, err := template.New("scalar_index.html").Parse(indexTmpl)
 	if err != nil {
 		panic(fmt.Errorf("fiber: scalar middleware error -> %w", err))
 	}


### PR DESCRIPTION
The output cannot be parsed with JSON.parse
This reverts commit 59486a1fa07d7074184e7e58815119d0b0978302.

## Summary by Sourcery

Reverts the previous commit that introduced escaping of the content, as it caused issues with JSON parsing.